### PR TITLE
fix: isolate extension CSS from Discogs (remove Bootstrap Reboot)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "searcher-for-discogs",
-  "version": "8.1.9",
+  "version": "8.1.10",
   "description": "Allows to listen to tracks on Discogs by clicking on it",
   "scripts": {
     "build": "node build/build.js buildType=test",
@@ -50,7 +50,7 @@
     "ts-jest": "^28.0.5",
     "ts-loader": "^9.3.1",
     "typescript": "^5.5.4",
-    "webpack": "^5.94.0",
+    "webpack": "5.104.1",
     "webpack-cli": "^5.1.4",
     "zip-folder": "^1.0.0"
   },

--- a/src/css/sfd.scss
+++ b/src/css/sfd.scss
@@ -1,12 +1,19 @@
-﻿.popover {
+.popover {
     max-width: 100%;
 }
 
 .discogs-searcher {
+    box-sizing: border-box;
     display: flex;
     justify-content: flex-end;
     align-items: center;
     padding-bottom: 9px;
+
+    *,
+    *::before,
+    *::after {
+        box-sizing: border-box;
+    }
 
     button {
         outline: none !important;

--- a/src/css/styles.scss
+++ b/src/css/styles.scss
@@ -3,9 +3,7 @@
 @import "bootstrap/scss/maps";
 @import "bootstrap/scss/mixins";
 @import "bootstrap/scss/root";
-@import "bootstrap/scss/utilities";
-@import "bootstrap/scss/reboot";
 @import "bootstrap/scss/popover";
 @import "bootstrap/scss/dropdown";
 
-@import "sfd.scss"
+@import "sfd.scss";


### PR DESCRIPTION
Stop injecting Bootstrap Reboot and utilities into the content script stylesheet so the host page layout is not reset. Add scoped box-sizing under .discogs-searcher for stable popover UI.

Fixes bbonch/searcher-for-discogs#3

How the extension UI element looks after changes (nothing changed):
 
<img width="903" height="543" alt="image" src="https://github.com/user-attachments/assets/8c94ca0c-2cd1-484e-8834-53b4624ad48a" />
